### PR TITLE
Show contribution value with hide_value=true if user has permission

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,3 @@
+module ApplicationHelper
+
+end

--- a/app/helpers/initiatives/contributions_helper.rb
+++ b/app/helpers/initiatives/contributions_helper.rb
@@ -1,0 +1,5 @@
+module Initiatives::ContributionsHelper
+  def can_manage_contribution? contribution
+    policy(contribution.initiative).update? || policy(contribution).update?
+  end
+end

--- a/app/models/gateway.rb
+++ b/app/models/gateway.rb
@@ -46,6 +46,10 @@ class Gateway < ActiveRecord::Base
     []
   end
 
+  # Overriden in gateway modules
+  def name
+  end
+
   private
 
   def include_gateway_module

--- a/app/views/initiatives/contributions/_contribution.json.jbuilder
+++ b/app/views/initiatives/contributions/_contribution.json.jbuilder
@@ -2,7 +2,7 @@
 json.id contribution.id
 json.user do |json|
   if contribution.hide_name?
-    if policy(contribution.initiative).update? || policy(contribution).update?
+    if can_manage_contribution?(contribution)
       json.id contribution.user.id
     end
     json.name Contribution.human_attribute_name(:hide_name?)
@@ -10,7 +10,7 @@ json.user do |json|
     json.id contribution.user.id
     json.name contribution.user.display_name
   end
-  if policy(contribution.initiative).update? || policy(contribution).update?
+  if can_manage_contribution?(contribution)
     json.email contribution.user.email
     json.full_name contribution.user.full_name
     json.document contribution.user.document
@@ -28,7 +28,7 @@ json.user do |json|
     json.updated_at contribution.user.updated_at
   end
 end
-json.value (contribution.hide_value ? nil : contribution.value)
+json.value ( (contribution.hide_value && !can_manage_contribution?(contribution)) ? nil : contribution.value)
 json.created_at contribution.created_at
 json.updated_at contribution.updated_at
 json.hide_name contribution.hide_name?

--- a/spec/controllers/contributions_controller_spec.rb
+++ b/spec/controllers/contributions_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Initiatives::ContributionsController, type: :controller do
+  render_views
+
+  subject{ response }
+  let(:user){ nil }
+
+  let(:initiative) { unlock_initiative }
+  let(:gateway) { initiative.gateways.first }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:set_locale).and_return(nil)
+  end
+
+  describe "#index" do
+    let(:contributions) { initiative.contributions.visible }
+    let(:user) { initiative.user }
+
+    before {
+      get :index, initiative_id: initiative.id
+    }
+
+    it { expect(assigns(:contributions)).to eq(contributions) }
+    it { is_expected.to render_template(:index) }
+  end
+
+  describe "#show" do
+    let(:user) { initiative.user }
+    let(:contribution) { get_contribution('active') }
+
+    before {
+      get :show, id: contribution.id, initiative_id: initiative.id
+    }
+
+    it { expect(assigns(:contribution)).to eq(contribution) }
+    it { expect(assigns(:user)).to eq(contribution.user) }
+    it { is_expected.to render_template(:show) }
+  end
+
+  describe "#show.json" do
+    let(:user) { initiative.user }
+    let(:contribution) { get_contribution('active') }
+    let(:body) { JSON.parse(response.body) }
+
+    before {
+      contribution.update_attributes(hide_value: true)
+      get :show, id: contribution.id, initiative_id: initiative.id, format: :json
+    }
+
+    it { expect(body['id']).to eq(contribution.id) }
+    it { expect(body['state']).to eq(contribution.state) }
+    it { expect(body['hide_value']).to eq(true) }
+
+    context "Logged out users can't see contribution value with hide_value=true" do
+      let(:user) { nil }
+      it { expect(body['value']).to eq(nil) }
+    end
+
+    context "Unrelated user user can't see contribution value with hide_value=true" do
+      let(:user) { get_user('new_user') }
+      it { expect(body['value']).to eq(nil) }
+    end
+
+  end
+
+end


### PR DESCRIPTION
Eu estou trabalhando num projeto com o pessoal da Escola Convexo (https://unlock.fund/pt-BR/escolaconvexo) e usamos o retorno JSON das contributions para o projeto deles para gerar alguns brindes para as pessoas que apoiam o projeto.

Até aí tudo bem, mas quando um apoio tem hide_value=true nós não conseguimos ler ele, mesmo como dono da Initiative (alias, este valor é visível pela interface).

Então essa pull request implementa isto, e adicionei testes para o controller e a minha feature.

Valeu pessoal.

