### PR TITLE
Show contribution value with hide_value=true if user has permission

### DIFF
--- a/app/decorators/contribution_decorator.rb
+++ b/app/decorators/contribution_decorator.rb
@@ -9,10 +9,13 @@ module ContributionDecorator
     day = self.created_at.strftime('%d').to_i
     until date do
       date = Date.strptime(day.to_s + Time.now.strftime('/%m/%Y'), '%d/%m/%Y') rescue nil
-      day -= 1    
+      day -= 1
     end
     date += 1.month if date < Time.now
     l date
   end
-  
+
+  def can_manage_contribution?
+    policy(self.initiative).update? || policy(self).update?
+  end
 end

--- a/app/models/gateway.rb
+++ b/app/models/gateway.rb
@@ -46,6 +46,10 @@ class Gateway < ActiveRecord::Base
     []
   end
 
+  # Overriden in gateway modules
+  def name
+  end
+
   private
 
   def include_gateway_module

--- a/app/views/initiatives/contributions/_contribution.json.jbuilder
+++ b/app/views/initiatives/contributions/_contribution.json.jbuilder
@@ -2,7 +2,7 @@
 json.id contribution.id
 json.user do |json|
   if contribution.hide_name?
-    if policy(contribution.initiative).update? || policy(contribution).update?
+    if contribution.can_manage_contribution?
       json.id contribution.user.id
     end
     json.name Contribution.human_attribute_name(:hide_name?)
@@ -10,7 +10,7 @@ json.user do |json|
     json.id contribution.user.id
     json.name contribution.user.display_name
   end
-  if policy(contribution.initiative).update? || policy(contribution).update?
+  if contribution.can_manage_contribution?
     json.email contribution.user.email
     json.full_name contribution.user.full_name
     json.document contribution.user.document
@@ -28,7 +28,7 @@ json.user do |json|
     json.updated_at contribution.user.updated_at
   end
 end
-json.value (contribution.hide_value ? nil : contribution.value)
+json.value ( (contribution.hide_value && !contribution.can_manage_contribution?) ? nil : contribution.value)
 json.created_at contribution.created_at
 json.updated_at contribution.updated_at
 json.hide_name contribution.hide_name?

--- a/spec/controllers/contributions_controller_spec.rb
+++ b/spec/controllers/contributions_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Initiatives::ContributionsController, type: :controller do
+  render_views
+
+  subject{ response }
+  let(:user){ nil }
+
+  let(:initiative) { unlock_initiative }
+  let(:gateway) { initiative.gateways.first }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:set_locale).and_return(nil)
+  end
+
+  describe "#index" do
+    let(:contributions) { initiative.contributions.visible }
+    let(:user) { initiative.user }
+
+    before {
+      get :index, initiative_id: initiative.id
+    }
+
+    it { expect(assigns(:contributions)).to eq(contributions) }
+    it { is_expected.to render_template(:index) }
+  end
+
+  describe "#show" do
+    let(:user) { initiative.user }
+    let(:contribution) { get_contribution('active') }
+
+    before {
+      get :show, id: contribution.id, initiative_id: initiative.id
+    }
+
+    it { expect(assigns(:contribution)).to eq(contribution) }
+    it { expect(assigns(:user)).to eq(contribution.user) }
+    it { is_expected.to render_template(:show) }
+  end
+
+  describe "#show.json" do
+    let(:user) { initiative.user }
+    let(:contribution) { get_contribution('active') }
+    let(:body) { JSON.parse(response.body) }
+
+    before {
+      contribution.update_attributes(hide_value: true)
+      get :show, id: contribution.id, initiative_id: initiative.id, format: :json
+    }
+
+    it { expect(body['id']).to eq(contribution.id) }
+    it { expect(body['state']).to eq(contribution.state) }
+    it { expect(body['hide_value']).to eq(true) }
+
+    context "Logged out users can't see contribution value with hide_value=true" do
+      let(:user) { nil }
+      it { expect(body['value']).to eq(nil) }
+    end
+
+    context "Unrelated user user can't see contribution value with hide_value=true" do
+      let(:user) { get_user('new_user') }
+      it { expect(body['value']).to eq(nil) }
+    end
+
+  end
+
+end


### PR DESCRIPTION
I'm working on a project with the good people of Escola Convexo (https://unlock.fund/pt-BR/escolaconvexo) and we use the JSON format of the contributions to generate some gifts certificates for people who support them.

So far so good, but when a contribution has `hide_value = true` we can't read, even thought we're the owner of the Initiative (by the way, this value is visible through the HTML interface).

So this pull request implements a correction for the JSON format, and I also added tests for the ContributionsController and my modifications.

Thanks :)

_New version with decorators instead of helpers_
